### PR TITLE
fix allocation implementation to resolve utf8 logic

### DIFF
--- a/guest/platform.h
+++ b/guest/platform.h
@@ -317,6 +317,10 @@ extern "C" {
 void env_read(uint8_t *bytes_ptr, uint32_t len);
 }
 
+extern "C" {
+void *env_alloc(uintptr_t size);
+}
+
 #if defined(DEFINE_SYSCALLS)
 /**
  * # Safety


### PR DESCRIPTION
Updates the allocation to fix the utf8 and related things, `sodium_init` is specifically what is failing there, and actually not sure where that call is being defined.

Docs seem to indicate that it assumes it makes some OS system calls (for things like randomness). Unclear the best path forward here intuitively. https://libsodium.gitbook.io/doc/usage#sodium_init-stalling-on-linux